### PR TITLE
[LLM] Fine-Tune LLMs via Prompt tuning

### DIFF
--- a/ludwig/backend/ray.py
+++ b/ludwig/backend/ray.py
@@ -51,7 +51,7 @@ from ludwig.distributed import get_default_strategy_name, get_dist_strategy, ini
 from ludwig.models.base import BaseModel
 from ludwig.models.predictor import BasePredictor, get_output_columns, Predictor, RemotePredictor
 from ludwig.schema.trainer import ECDTrainerConfig
-from ludwig.trainers.registry import ray_trainers_registry, register_ray_trainer
+from ludwig.trainers.registry import get_llm_ray_trainers_registry, get_ray_trainers_registry, register_ray_trainer
 from ludwig.trainers.trainer import BaseTrainer, RemoteTrainer, Trainer
 from ludwig.trainers.trainer_llm import RemoteLLMTrainer
 from ludwig.types import HyperoptConfigDict, ModelConfigDict, TrainerConfigDict, TrainingSetMetadataDict
@@ -846,7 +846,12 @@ class RayBackend(RemoteTrainingMixin, Backend):
     def create_trainer(self, model: BaseModel, **kwargs) -> "BaseTrainer":  # noqa: F821
         executable_kwargs = {**kwargs, **self._pytorch_kwargs}
 
-        trainer_cls = get_from_registry(model.type(), ray_trainers_registry)
+        if model.type() == MODEL_LLM:
+            trainer_config = kwargs.get("config")
+            trainer_type = trainer_config.type or "zeroshot"  # fallback to zeroshot
+            trainer_cls = get_from_registry(trainer_type, get_llm_ray_trainers_registry())
+        else:
+            trainer_cls = get_from_registry(model.type(), get_ray_trainers_registry())
 
         all_kwargs = {
             "model": model,

--- a/ludwig/constants.py
+++ b/ludwig/constants.py
@@ -275,6 +275,9 @@ PREPROCESSOR = "preprocessor"
 PREDICTOR = "predictor"
 POSTPROCESSOR = "postprocessor"
 
+GENERATION = "generation"
+ADAPTER = "adapter"
+
 S3 = "s3"
 CACHE = "cache"
 

--- a/ludwig/models/llm.py
+++ b/ludwig/models/llm.py
@@ -18,9 +18,8 @@ from ludwig.schema.features.base import BaseOutputFeatureConfig, FeatureCollecti
 from ludwig.schema.model_types.llm import LLMModelConfig
 from ludwig.utils.augmentation_utils import AugmentationPipelines
 from ludwig.utils.data_utils import clear_data_cache
-from ludwig.utils.fs_utils import open_file
-from ludwig.utils.state_dict_backward_compatibility import update_state_dict
-from ludwig.utils.torch_utils import get_torch_device
+from ludwig.utils.logging_utils import log_once
+from ludwig.utils.output_feature_utils import set_output_feature_tensor
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +48,24 @@ class LLM(BaseModel):
         self.curr_device = torch.device("cpu")  # model initially loaded onto cpu
         logger.info("Done.")
 
-        self.max_new_tokens = self.config_obj.generation.max_new_tokens
+        # If an adapter config is provided, we want to wrap the model with a PEFT model
+        # for fine-tuning.
+        if self.config_obj.adapter:
+            from peft import get_peft_config, get_peft_model
+
+            # Set tokenizer_name_or_path to the model name since it is required by all PEFT adapter config
+            self.config_obj.adapter.tokenizer_name_or_path = self.model_name
+
+            # Deepcopy and remove type manually since it is not a valid argument for the adapter config
+            adapter_config = copy.deepcopy(self.config_obj.adapter.to_dict())
+            adapter_config.pop("type", None)
+
+            self.model = get_peft_model(self.model, get_peft_config(adapter_config))
+
+            logger.info("==================================================")
+            logger.info("Trainable Parameter Summary For Fine-Tuning:")
+            self.model.print_trainable_parameters()
+            logger.info("==================================================")
 
         # Determines the maximum length of the context (input + output tokens)
         if hasattr(self.model.config, "max_sequence_length"):
@@ -58,8 +74,10 @@ class LLM(BaseModel):
             self.context_len = self.model.config.max_position_embeddings
         else:
             self.context_len = 2048
+
         # max input length value copied from FastChat
         # https://github.com/lm-sys/FastChat/blob/0e958b852a14f4bef5f0e9d7a5e7373477329cf2/fastchat/serve/inference.py#L183  # noqa
+        self.max_new_tokens = self.config_obj.generation.max_new_tokens
         self.max_input_length = self.context_len - self.max_new_tokens - 8
 
         # Used only for its metadata about the vocabulary
@@ -77,7 +95,14 @@ class LLM(BaseModel):
 
         # ================ Outputs ================
         self.output_features.update(
-            self.build_outputs(output_feature_configs=self.config_obj.output_features, input_size=self.input_shape[-1])
+            self.build_outputs(
+                output_feature_configs=self.config_obj.output_features,
+                # Set the input size to the model vocab size instead of the tokenizer vocab size
+                # because the model has additional "head" layers that are used to predict the next
+                # token in the sequence. These head layers can add additional dimensions to the
+                # logits tensor, beyond the vocab_size dimension.
+                input_size=self.model.config.vocab_size,
+            )
         )
 
         # Extract the decoder object for the forward pass
@@ -92,10 +117,9 @@ class LLM(BaseModel):
     def to_device(self, device):
         device = torch.device(device)
         if device == self.curr_device:
-            logger.warning(f"LLM already on device '{device}'. Skipping device placement step.")
             return self
         else:
-            logger.info(f"Moving LLM from '{self.curr_device}' to '{device}'.")
+            log_once(f"Moving LLM from '{self.curr_device}' to '{device}'.")
 
         model_kwargs = {}
         if device == torch.device("cuda"):
@@ -142,6 +166,15 @@ class LLM(BaseModel):
 
         return output_features
 
+    def get_input_ids(
+        self,
+        inputs: Union[
+            Dict[str, torch.Tensor], Dict[str, np.ndarray], Tuple[Dict[str, torch.Tensor], Dict[str, torch.Tensor]]
+        ],
+    ):
+        """Returns the input ids for the text feature input."""
+        return inputs[self.config_obj.input_features[0].name].type(torch.int32)
+
     def forward(
         self,
         inputs: Union[
@@ -175,9 +208,20 @@ class LLM(BaseModel):
 
         assert list(inputs.keys()) == self.input_features.keys()
 
-        with torch.no_grad():
-            input_ids = self.get_input_ids(inputs)
+        input_ids = self.get_input_ids(inputs)
 
+        if self.config_obj.adapter:
+            # Forward pass using PEFT model for fine-tuning
+            model_outputs = self.model(input_ids)
+            # Pass generated tokens through decoder after averaging the token probabilities
+            logits_with_averaged_token_probabilities = torch.mean(model_outputs[LOGITS], dim=1)
+            decoder_outputs = self.output_feature_decoder.decoder_obj(logits_with_averaged_token_probabilities)
+            # Set the output feature tensor to the decoder outputs (logits)
+            outputs = {}
+            set_output_feature_tensor(outputs, self.config_obj.output_features[0].name, LOGITS, decoder_outputs)
+            return outputs
+
+        with torch.no_grad():
             input_lengths = []
             sequences_list = []
             for input_ids_sample in input_ids:
@@ -208,18 +252,17 @@ class LLM(BaseModel):
                 sequences_list,
                 llm_model_input_lengths=input_lengths,
             )
-        return self.extract(outputs)
 
-    def get_input_ids(self, inputs):
-        """Returns the input ids for the text feature input."""
-        return inputs[self.config_obj.input_features[0].name].type(torch.int32)
+        return self.extract(outputs)
 
     def extract(
         self,
         outputs,
     ):
         """Extracts predictions and probabilities from the model outputs."""
-        return {self.config_obj.output_features[0].name: outputs}
+        return {
+            self.config_obj.output_features[0].name: outputs,
+        }
 
     def update_metrics(self, targets, predictions):
         """Updates the model's metrics given targets and predictions."""
@@ -273,24 +316,31 @@ class LLM(BaseModel):
         """Returns the model's predictions for each output feature."""
         predictions = {}
         for of_name in self.output_features:
-            generated_predictions = outputs[of_name]
-            predictions[of_name] = generated_predictions
+            if self.config_obj.adapter:
+                predictions[of_name] = self.output_features.get(of_name).predictions(outputs, of_name)
+            else:
+                generated_predictions = outputs[of_name]
+                predictions[of_name] = generated_predictions
         return predictions
 
     def save(self, save_path):
         """Saves the model to the given path."""
-        # TODO: figure out what we want to do about weight saving for LLMs.
-        # weights_save_path = os.path.join(save_path, MODEL_WEIGHTS_FILE_NAME)
-        # torch.save(self.state_dict(), weights_save_path)
-        logger.warning("Saving LLMs is not yet supported.")
+        if self.config_obj.adapter:
+            weights_save_path = os.path.join(save_path, MODEL_WEIGHTS_FILE_NAME)
+            self.model.save_pretrained(weights_save_path)
+        else:
+            logger.info("Skipped saving LLM without weight adjustments.")
 
     def load(self, save_path):
         """Loads the model from the given path."""
-        weights_save_path = os.path.join(save_path, MODEL_WEIGHTS_FILE_NAME)
-        device = torch.device(get_torch_device())
-        with open_file(weights_save_path, "rb") as f:
-            state_dict = torch.load(f, map_location=device)
-            self.load_state_dict(update_state_dict(state_dict))
+        if self.config_obj.adapter:
+            from peft import PeftConfig, PeftModel  # noqa
+
+            weights_save_path = os.path.join(save_path, MODEL_WEIGHTS_FILE_NAME)
+            config = PeftConfig.from_pretrained(weights_save_path)
+            config.inference_mode = False
+            self.model = AutoModelForCausalLM.from_pretrained(config.base_model_name_or_path)
+            self.model = PeftModel.from_pretrained(self.model, weights_save_path)
 
     def get_args(self):
         """Returns init arguments for constructing this model."""

--- a/ludwig/models/retrieval.py
+++ b/ludwig/models/retrieval.py
@@ -80,7 +80,6 @@ class RandomRetrieval(RetrievalModel):
     def search(
         self, df, backend: "Backend", k: int = 10, return_data: bool = False
     ) -> Union[List[int], List[Dict[str, Any]]]:
-
         results = []
         for _ in tqdm(range(len(df))):
             indices = np.random.choice(self.index, k, replace=False)

--- a/ludwig/schema/adapter.py
+++ b/ludwig/schema/adapter.py
@@ -1,0 +1,145 @@
+from abc import ABC
+from typing import Optional, Type
+
+from ludwig.api_annotations import DeveloperAPI
+from ludwig.schema import utils as schema_utils
+from ludwig.utils.registry import Registry
+
+_adapter_registry = Registry()
+
+
+@DeveloperAPI
+def register_adapter(name: str):
+    """Registers an adapter config class with the adapter config registry."""
+
+    def wrap(adapter_config: BaseAdapterConfig):
+        _adapter_registry[name] = adapter_config
+        return adapter_config
+
+    return wrap
+
+
+@DeveloperAPI
+def get_adapter_cls(name: str):
+    """Returns the adapter config class registered with the given name."""
+    return _adapter_registry[name]
+
+
+@DeveloperAPI
+@schema_utils.ludwig_dataclass
+class BaseAdapterConfig(schema_utils.BaseMarshmallowConfig, ABC):
+    """Base class for adapter configs.
+
+    Not meant to be used directly.
+    """
+
+    task_type: str = schema_utils.ProtectedString("CAUSAL_LM")
+
+
+@DeveloperAPI
+@register_adapter("prompt_tuning")
+@schema_utils.ludwig_dataclass
+class PromptTuningAdapterConfig(BaseAdapterConfig):
+    # Explicitly set type property in the config because it is needed when we
+    # load a saved PEFT model back into Ludwig.
+    type: str = schema_utils.ProtectedString("prompt_tuning")
+
+    peft_type: str = schema_utils.ProtectedString("PROMPT_TUNING")
+
+    num_virtual_tokens: Optional[int] = schema_utils.Integer(
+        default=None,
+        allow_none=True,
+        description="Number of virtual tokens to add to the prompt. Virtual tokens are used to control the behavior of "
+        " the model during inference. ",
+    )
+
+    token_dim: Optional[int] = schema_utils.Integer(
+        default=None,
+        allow_none=True,
+        description="The hidden embedding dimension of the base transformer model.",
+    )
+
+    num_transformer_submodules: Optional[int] = schema_utils.Integer(
+        default=None,
+        allow_none=True,
+        description="The number of transformer submodules in the base transformer model.",
+    )
+
+    num_attention_heads: Optional[int] = schema_utils.Integer(
+        default=None,
+        allow_none=True,
+        description="The number of attention heads in the base transformer model.",
+    )
+
+    num_layers: Optional[int] = schema_utils.Integer(
+        default=None,
+        allow_none=True,
+        description="The number of layers in the base transformer model.",
+    )
+
+    # TODO(Arnav): Refactor to allow both RANDOM and TEXT strategies
+    prompt_tuning_init: str = schema_utils.ProtectedString(
+        "TEXT", description="The type of initialization to use for the prompt embedding. "
+    )
+
+    prompt_tuning_init_text: str = schema_utils.String(
+        default="",
+        allow_none=False,
+        description="The text to use to initialize the prompt embedding.",
+    )
+
+
+@DeveloperAPI
+def get_adapter_conds():
+    """Returns a JSON schema of conditionals to validate against adapter types."""
+    conds = []
+    for adapter in _adapter_registry:
+        adapter_cls = _adapter_registry[adapter]
+        other_props = schema_utils.unload_jsonschema_from_marshmallow_class(adapter_cls)["properties"]
+        schema_utils.remove_duplicate_fields(other_props)
+        preproc_cond = schema_utils.create_cond(
+            {"type": adapter},
+            other_props,
+        )
+        conds.append(preproc_cond)
+    return conds
+
+
+@DeveloperAPI
+def AdapterDataclassField(default=None, description=""):
+    class AdapterSelection(schema_utils.TypeSelection):
+        def __init__(self):
+            super().__init__(
+                registry=_adapter_registry,
+                default_value=default,
+                description=description,
+            )
+
+        def get_schema_from_registry(self, key: str) -> Type[schema_utils.BaseMarshmallowConfig]:
+            return get_adapter_cls(key)
+
+        def _jsonschema_type_mapping(self):
+            return {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": list(_adapter_registry.keys()),
+                                "default": default,
+                                "description": "The type of adapter to use for LLM fine-tuning",
+                            },
+                        },
+                        "title": "adapter_options",
+                        "allOf": get_adapter_conds(),
+                        "required": ["type"],
+                        "description": description,
+                    },
+                    {
+                        "type": "null",
+                    },
+                ]
+            }
+
+    return AdapterSelection().get_default_field()

--- a/ludwig/schema/decoders/base.py
+++ b/ludwig/schema/decoders/base.py
@@ -2,7 +2,7 @@ from abc import ABC
 from typing import Dict, List, Tuple, Union
 
 from ludwig.api_annotations import DeveloperAPI
-from ludwig.constants import BINARY, CATEGORY, MODEL_ECD, MODEL_GBM, NUMBER, SET, TIMESERIES, VECTOR
+from ludwig.constants import BINARY, CATEGORY, MODEL_ECD, MODEL_GBM, MODEL_LLM, NUMBER, SET, TIMESERIES, VECTOR
 from ludwig.schema import common_fields
 from ludwig.schema import utils as schema_utils
 from ludwig.schema.decoders.utils import register_decoder_config
@@ -224,7 +224,7 @@ class ProjectorConfig(BaseDecoderConfig):
 
 
 @DeveloperAPI
-@register_decoder_config("classifier", [CATEGORY, SET], model_types=[MODEL_ECD, MODEL_GBM])
+@register_decoder_config("classifier", [CATEGORY, SET], model_types=[MODEL_ECD, MODEL_GBM, MODEL_LLM])
 @ludwig_dataclass
 class ClassifierConfig(BaseDecoderConfig):
     @classmethod

--- a/ludwig/schema/model_types/llm.py
+++ b/ludwig/schema/model_types/llm.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from ludwig.api_annotations import DeveloperAPI
 from ludwig.schema import utils as schema_utils
+from ludwig.schema.adapter import AdapterDataclassField, BaseAdapterConfig
 from ludwig.schema.defaults.llm import LLMDefaultsConfig, LLMDefaultsField
 from ludwig.schema.features.base import (
     BaseInputFeatureConfig,
@@ -14,7 +15,7 @@ from ludwig.schema.generation import LLMGenerationConfig, LLMGenerationConfigFie
 from ludwig.schema.hyperopt import HyperoptConfig, HyperoptField
 from ludwig.schema.model_types.base import ModelConfig, register_model_type
 from ludwig.schema.preprocessing import PreprocessingConfig, PreprocessingField
-from ludwig.schema.trainer import LLMTrainerConfig, LLMTrainerField
+from ludwig.schema.trainer import LLMTrainerConfig, LLMTrainerDataclassField
 from ludwig.schema.utils import ludwig_dataclass
 
 
@@ -38,12 +39,22 @@ class LLMModelConfig(ModelConfig):
         ),
     )
 
-    generation: LLMGenerationConfig = LLMGenerationConfigField().get_default_field()
-
     input_features: FeatureCollection[BaseInputFeatureConfig] = LLMInputFeatureSelection().get_list_field()
     output_features: FeatureCollection[BaseOutputFeatureConfig] = LLMOutputFeatureSelection().get_list_field()
 
-    trainer: LLMTrainerConfig = LLMTrainerField().get_default_field()
     preprocessing: PreprocessingConfig = PreprocessingField().get_default_field()
     defaults: Optional[LLMDefaultsConfig] = LLMDefaultsField().get_default_field()
     hyperopt: Optional[HyperoptConfig] = HyperoptField().get_default_field()
+
+    # trainer: LLMTrainerConfig = LLMTrainerField().get_default_field()
+    trainer: LLMTrainerConfig = LLMTrainerDataclassField(
+        default="zeroshot",
+        description="The trainer to use for the model",
+    )
+
+    generation: LLMGenerationConfig = LLMGenerationConfigField().get_default_field()
+
+    adapter: BaseAdapterConfig = AdapterDataclassField(
+        default=None,
+        description="The adapter to use for the model. This is used for PEFT based fine-tuning",
+    )

--- a/ludwig/schema/trainer.py
+++ b/ludwig/schema/trainer.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Optional, Union
+from typing import Optional, Type, Union
 
 import torch
 from packaging.version import parse as parse_version
@@ -31,6 +31,7 @@ _torch_200 = parse_version(torch.__version__) >= parse_version("2.0")
 
 
 trainer_schema_registry = Registry()
+_llm_trainer_schema_registry = Registry()
 
 
 @DeveloperAPI
@@ -40,6 +41,21 @@ def register_trainer_schema(model_type: str):
         return trainer_config
 
     return wrap
+
+
+@DeveloperAPI
+def register_llm_trainer_schema(trainer_type: str):
+    def wrap(trainer_config: BaseTrainerConfig):
+        _llm_trainer_schema_registry[trainer_type] = trainer_config
+        return trainer_config
+
+    return wrap
+
+
+@DeveloperAPI
+def get_llm_trainer_cls(trainer_type: str):
+    """Returns the adapter config class registered with the given name."""
+    return _llm_trainer_schema_registry[trainer_type]
 
 
 @DeveloperAPI
@@ -691,7 +707,6 @@ class GBMTrainerConfig(BaseTrainerConfig):
 
 
 @DeveloperAPI
-@register_trainer_schema(MODEL_LLM)
 @ludwig_dataclass
 class LLMTrainerConfig(BaseTrainerConfig):
     """Base class for all LLM trainer configs."""
@@ -753,12 +768,38 @@ class LLMTrainerConfig(BaseTrainerConfig):
 
 
 @DeveloperAPI
-@register_trainer_schema(MODEL_LLM)
+@register_llm_trainer_schema("zeroshot")
 @ludwig_dataclass
 class ZeroShotTrainerConfig(LLMTrainerConfig):
     """Dataclass that configures most of the hyperparameters used for zero-shot LLM model training."""
 
-    pass
+    # Required for lookup during trainer initialization
+    type: str = schema_utils.ProtectedString("zeroshot")
+
+
+@DeveloperAPI
+@register_llm_trainer_schema("fewshot")
+@ludwig_dataclass
+class FewShotTrainerConfig(LLMTrainerConfig):
+    """Dataclass that configures most of the hyperparameters used for zero-shot LLM model training."""
+
+    # Required for lookup during trainer initialization
+    type: str = schema_utils.ProtectedString("fewshot")
+
+
+@DeveloperAPI
+@register_llm_trainer_schema("finetune")
+@ludwig_dataclass
+class FineTuneTrainerConfig(ECDTrainerConfig):
+    """Dataclass that configures most of the hyperparameters used for fine-tuning LLM model training."""
+
+    # Required for lookup during trainer initialization
+    type: str = schema_utils.ProtectedString("finetune")
+
+    base_learning_rate: float = schema_utils.NonNegativeFloat(
+        default=0.0,
+        description="Base learning rate used for training in the LLM trainer.",
+    )
 
 
 @DeveloperAPI
@@ -793,6 +834,20 @@ def get_trainer_jsonschema(model_type: str):
 
 
 @DeveloperAPI
+def get_llm_trainer_jsonschema(trainer_type: str):
+    trainer_cls = _llm_trainer_schema_registry[trainer_type]
+    props = schema_utils.unload_jsonschema_from_marshmallow_class(trainer_cls)["properties"]
+
+    return {
+        "type": "object",
+        "properties": props,
+        "title": "trainer_options",
+        "additionalProperties": False,
+        "description": "Schema for LLM trainer determined by trainer type",
+    }
+
+
+@DeveloperAPI
 class ECDTrainerField(schema_utils.DictMarshmallowField):
     def __init__(self):
         super().__init__(ECDTrainerConfig)
@@ -811,9 +866,49 @@ class GBMTrainerField(schema_utils.DictMarshmallowField):
 
 
 @DeveloperAPI
-class LLMTrainerField(schema_utils.DictMarshmallowField):
-    def __init__(self):
-        super().__init__(ZeroShotTrainerConfig)
+def get_llm_trainer_conds():
+    """Returns a JSON schema of conditionals to validate against adapter types."""
+    conds = []
+    for trainer in _llm_trainer_schema_registry:
+        trainer_cls = _llm_trainer_schema_registry[trainer]
+        other_props = schema_utils.unload_jsonschema_from_marshmallow_class(trainer_cls)["properties"]
+        schema_utils.remove_duplicate_fields(other_props)
+        preproc_cond = schema_utils.create_cond(
+            {"type": trainer},
+            other_props,
+        )
+        conds.append(preproc_cond)
+    return conds
 
-    def _jsonschema_type_mapping(self):
-        return get_trainer_jsonschema(MODEL_LLM)
+
+@DeveloperAPI
+def LLMTrainerDataclassField(default="zeroshot", description=""):
+    class LLMTrainerSelection(schema_utils.TypeSelection):
+        def __init__(self):
+            super().__init__(
+                registry=_llm_trainer_schema_registry,
+                default_value=default,
+                description=description,
+            )
+
+        def get_schema_from_registry(self, key: str) -> Type[schema_utils.BaseMarshmallowConfig]:
+            return get_llm_trainer_cls(key)
+
+        def _jsonschema_type_mapping(self):
+            return {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": list(_llm_trainer_schema_registry.keys()),
+                        "default": default,
+                        "description": "The type of optimizer to use during the learning process",
+                    },
+                },
+                "title": "optimizer_options",
+                "allOf": get_llm_trainer_conds(),
+                "required": ["type"],
+                "description": description,
+            }
+
+    return LLMTrainerSelection().get_default_field()

--- a/ludwig/trainers/registry.py
+++ b/ludwig/trainers/registry.py
@@ -1,9 +1,34 @@
+from ludwig.api_annotations import DeveloperAPI
 from ludwig.utils.registry import DEFAULT_KEYS, Registry
 
-trainers_registry = Registry()
-ray_trainers_registry = Registry()
+_trainers_registry = Registry()
+_ray_trainers_registry = Registry()
+
+_llm_trainers_registry = Registry()
+_llm_ray_trainers_registry = Registry()
 
 
+@DeveloperAPI
+def get_trainers_registry() -> Registry:
+    return _trainers_registry
+
+
+@DeveloperAPI
+def get_ray_trainers_registry() -> Registry:
+    return _ray_trainers_registry
+
+
+@DeveloperAPI
+def get_llm_trainers_registry() -> Registry:
+    return _llm_trainers_registry
+
+
+@DeveloperAPI
+def get_llm_ray_trainers_registry() -> Registry:
+    return _llm_ray_trainers_registry
+
+
+@DeveloperAPI
 def register_trainer(model_type: str, default=False):
     """Register a trainer class that supports training the given model types.
 
@@ -15,17 +40,18 @@ def register_trainer(model_type: str, default=False):
     """
 
     def wrap(cls):
-        trainers_registry[model_type] = cls
+        _trainers_registry[model_type] = cls
         if default:
-            if DEFAULT_KEYS[0] in trainers_registry:
+            if DEFAULT_KEYS[0] in _trainers_registry:
                 raise ValueError(f"Default trainer already registered for model type {model_type}")
             for key in DEFAULT_KEYS:
-                trainers_registry[key] = cls
+                _trainers_registry[key] = cls
         return cls
 
     return wrap
 
 
+@DeveloperAPI
 def register_ray_trainer(model_type: str, default=False):
     """Register a trainer class that supports training the given model types with Ray backend.
 
@@ -37,12 +63,59 @@ def register_ray_trainer(model_type: str, default=False):
     """
 
     def wrap(cls):
-        ray_trainers_registry[model_type] = cls
+        _ray_trainers_registry[model_type] = cls
         if default:
-            if DEFAULT_KEYS[0] in ray_trainers_registry:
+            if DEFAULT_KEYS[0] in _ray_trainers_registry:
                 raise ValueError(f"Default trainer already registered for model type {model_type}")
             for key in DEFAULT_KEYS:
-                ray_trainers_registry[key] = cls
+                _ray_trainers_registry[key] = cls
+        return cls
+
+    return wrap
+
+
+@DeveloperAPI
+def register_llm_trainer(trainer_type: str, default=False):
+    """Register a trainer class that supports training the specific type of training strategy for LLM Models.
+
+    Using default=True will make the trainer the default trainer for the LLM model type.
+
+    Args:
+        trainer_type: The trainer_type which dictates what training strategy to use.
+        default: Whether the trainer should be the default trainer for LLMs.
+    """
+
+    def wrap(cls):
+        _llm_trainers_registry[trainer_type] = cls
+        if default:
+            if DEFAULT_KEYS[0] in _trainers_registry:
+                raise ValueError(f"Default trainer {trainer_type} already registered for LLM")
+            for key in DEFAULT_KEYS:
+                _llm_trainers_registry[key] = cls
+        return cls
+
+    return wrap
+
+
+@DeveloperAPI
+def register_llm_ray_trainer(trainer_type: str, default=False):
+    """Register a trainer class that supports training the specific type of training strategy for LLM Models with
+    Ray backend.
+
+    Using default=True will make the trainer the default trainer for the LLM model type.
+
+    Args:
+        trainer_type: The trainer_type which dictates what training strategy to use.
+        default: Whether the trainer should be the default trainer for LLMs.
+    """
+
+    def wrap(cls):
+        _llm_ray_trainers_registry[trainer_type] = cls
+        if default:
+            if DEFAULT_KEYS[0] in _trainers_registry:
+                raise ValueError(f"Default ray trainer {trainer_type} already registered for LLM")
+            for key in DEFAULT_KEYS:
+                _llm_ray_trainers_registry[key] = cls
         return cls
 
     return wrap

--- a/ludwig/utils/backward_compatibility.py
+++ b/ludwig/utils/backward_compatibility.py
@@ -682,17 +682,21 @@ def _upgrade_max_batch_size(trainer: TrainerConfigDict) -> TrainerConfigDict:
     return trainer
 
 
-@register_config_transformation("0.6", ["trainer"])
-def remove_trainer_type(trainer: TrainerConfigDict) -> TrainerConfigDict:
-    if TYPE in trainer:
+@register_config_transformation("0.6")
+def remove_trainer_type(config: ModelConfigDict) -> ModelConfigDict:
+    # LLM Model types support different trainer types
+    if config.get("model_type", None) == "llm":
+        return config
+
+    if TYPE in config.get("trainer", {}):
         warnings.warn(
             "Config param `type` has been removed from the trainer. The trainer type is determined by the top level "
             " `model_type` parameter. Support for the `type` params in trainer will be removed in v0.8",
             DeprecationWarning,
         )
-        del trainer[TYPE]
+        del config["trainer"][TYPE]
 
-    return trainer
+    return config
 
 
 @register_config_transformation("0.7", ["trainer"])


### PR DESCRIPTION
Recreated from original PR: https://github.com/ludwig-ai/ludwig/pull/3359

This PR adds the ability to fine-tune LLM model types via Prompt Tuning using PEFT. The only change required to the config is as follows:

```yaml
adapter:
    type: prompt_tuning
    num_virtual_tokens: 32
    prompt_tuning_init_text: "Rate this review from 1 through 5:"
```

This considerably reduces the number of parameters required to fine-tune by keeping the pretrained LLMs weights frozen while adding an adapter (in this case, a PromptEmbeddingLayer) to fine-tune the weights of the...